### PR TITLE
Remove "setMinRequestAmount" and "setMaxRequestAmount" from FundingVault.

### DIFF
--- a/app/blockchain/src/FundingVault.sol
+++ b/app/blockchain/src/FundingVault.sol
@@ -144,28 +144,6 @@ contract FundingVault is Ownable, ReentrancyGuard {
     }
 
     /**
-     * @param _minRequestableAmount The minimum amount of token that can be requested in proposal
-     * @notice Only the owner can call this function
-     */
-    function setMinRequestableAmount(uint256 _minRequestableAmount) public onlyOwner {
-        if (_minRequestableAmount > s_maxRequestableAmount) {
-            revert FundingVault__MinRequestableAmountCannotBeGreaterThanMaxRequestableAmount();
-        }
-        s_minRequestableAmount = _minRequestableAmount;
-    }
-
-    /**
-     * @param _maxRequestableAmount The maximum amount of token that can be requested in proposal
-     * @notice Only the owner can call this function
-     */
-    function setMaxRequestableAmount(uint256 _maxRequestableAmount) public onlyOwner {
-        if (_maxRequestableAmount <= s_minRequestableAmount) {
-            revert FundingVault__MaxRequestableAmountCannotBeLessThanMinRequestableAmount();
-        }
-        s_maxRequestableAmount = _maxRequestableAmount;
-    }
-
-    /**
      * @dev Allows users to deposit fundingToken into the vault
      * @param _amount The amount of fundingToken to deposit
      */

--- a/app/blockchain/test/fuzz/FundingVault.t.sol
+++ b/app/blockchain/test/fuzz/FundingVault.t.sol
@@ -41,20 +41,6 @@ contract FundingVaultTest is Test {
         votingPowerToken.transferOwnership(address(fundingVault));
     }
 
-    function testFuzzSetMinRequestableAmount(uint96 _minRequestableAmount) public {
-        vm.assume(_minRequestableAmount <= 10 ether);
-        vm.prank(owner);
-        fundingVault.setMinRequestableAmount(_minRequestableAmount);
-        assertEq(fundingVault.getMinRequestableAmount(), _minRequestableAmount);
-    }
-
-    function testFuzzSetMaxRequestableAmount(uint96 _maxRequestableAmount) public {
-        vm.assume(_maxRequestableAmount > 0);
-        vm.prank(owner);
-        fundingVault.setMaxRequestableAmount(_maxRequestableAmount);
-        assertEq(fundingVault.getMaxRequestableAmount(), _maxRequestableAmount);
-    }
-
     function testFuzzDeposit(uint96 _amount) public {
         vm.assume(_amount > 0);
         fundingToken.mint(address(this), _amount);

--- a/app/blockchain/test/unit/FundingVault.t.sol
+++ b/app/blockchain/test/unit/FundingVault.t.sol
@@ -33,26 +33,6 @@ contract FundingVaultTest is Test {
         votingPowerToken.transferOwnership(address(fundingVault));
     }
 
-    function testSetMinRequestableAmount() public {
-        vm.prank(owner);
-        fundingVault.setMinRequestableAmount(2 ether);
-        assertEq(fundingVault.getMinRequestableAmount(), 2 ether);
-    }
-
-    function testFailSetMinRequestableAmount() public {
-        fundingVault.setMinRequestableAmount(11 ether);
-    }
-
-    function testSetMaxRequestableAmount() public {
-        vm.prank(owner);
-        fundingVault.setMaxRequestableAmount(20 ether);
-        assertEq(fundingVault.getMaxRequestableAmount(), 20 ether);
-    }
-
-    function testFailSetMaxRequestableAmount() public {
-        fundingVault.setMaxRequestableAmount(0);
-    }
-
     function testDeposit() public {
         vm.startPrank(randomUser);
         fundingToken.mint(randomUser, 10 ether);
@@ -553,22 +533,6 @@ contract FundingVaultTest is Test {
         vm.startPrank(randomUser);
         vm.expectRevert(FundingVault.FundingVault__NoRemainingFundsToWithdraw.selector);
         fundingVault.withdrawRemaining();
-    }
-
-    function testGetMinRequestableAmount() public {
-        assertEq(fundingVault.getMinRequestableAmount(), 1);
-
-        vm.prank(owner);
-        fundingVault.setMinRequestableAmount(2 ether);
-        assertEq(fundingVault.getMinRequestableAmount(), 2 ether);
-    }
-
-    function testGetMaxRequestableAmount() public {
-        assertEq(fundingVault.getMaxRequestableAmount(), 10 ether);
-
-        vm.prank(owner);
-        fundingVault.setMaxRequestableAmount(20 ether);
-        assertEq(fundingVault.getMaxRequestableAmount(), 20 ether);
     }
 
     function testGetTallyDate() public view {


### PR DESCRIPTION
## Closes #18 
# Changes:
## Smart Contract:
- Removed setMinRequestAmount and setMaxRequestAmount from FundingVault.

After reconsideration, we concluded that these functions should not be part of the FundingVault. Allowing these functions would grant unnecessary control to the vault creator, which contradicts the principles of decentralization.

