### PR TITLE
 Fix: Correct Deployment Command for Sepolia Testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ FairFund is a blockchain based platform for community-driven funding. Users can 
     ```
     - Deploy the contract:
     ```bash
-    deploy-sepolia
+    make deploy-sepolia
     ```
 
 ### Frontend


### PR DESCRIPTION
This PR addresses an issue with the deployment command for the Sepolia testnet. 
Previously, the command `deploy-sepolia` was used, which resulted in a "command not found" error. 
The correct command should be `make deploy-sepolia,`