### PR TITLE
fix:add css to remove scrollbar

### DIFF
--- a/app/web-app/src/app/globals.css
+++ b/app/web-app/src/app/globals.css
@@ -75,3 +75,12 @@
         @apply bg-background text-foreground;
     }
 }
+
+::-webkit-scrollbar {
+    display: none; 
+  }
+  
+  * {
+    -ms-overflow-style: none;  
+    scrollbar-width: none;    
+  }


### PR DESCRIPTION
Overview  
This pull request addresses the issue #49 of the scrollbar's appearance during page transitions in the dashboard and spaces pages. By modifying the global CSS, the scrollbar will now be hidden when not needed, ensuring a smoother user experience.

**Changes**  
Added the following CSS rules to the `global.css` file to hide the scrollbar when it is not in use:

```css
::-webkit-scrollbar {
    display: none; 
}
  
* {
    -ms-overflow-style: none;  
    scrollbar-width: none;    
}
```

Impact These changes will prevent the scrollbar from appearing enhance the transition experience to the spaces page by avoiding odd adjustments to the navigation bar. This results in a cleaner and more consistent interface for users.

