### PR TITLE
Enhance Funding Vault Creation: Add Support for Custom Vault Titles with Backward Compatibility

### DIFF
--- a/app/web-app/prisma/migrations/20241210102725_add_name_field_in_funding_vault_model/migration.sql
+++ b/app/web-app/prisma/migrations/20241210102725_add_name_field_in_funding_vault_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "FundingVault" ADD COLUMN     "name" TEXT;

--- a/app/web-app/prisma/schema.prisma
+++ b/app/web-app/prisma/schema.prisma
@@ -39,6 +39,7 @@ model Space {
 
 model FundingVault {
   id                       Int      @id @default(autoincrement())
+  name                     String?
   description              String
   creatorAddress           String
   fundingTokenAddress      String

--- a/app/web-app/src/app/(root)/profile/page.tsx
+++ b/app/web-app/src/app/(root)/profile/page.tsx
@@ -224,10 +224,13 @@ export default async function ProfilePage() {
                                             icon={
                                                 <Vault className="h-5 w-5 text-purple-500" />
                                             }
-                                            title={truncateText(
-                                                vault.description,
-                                                50
-                                            )}
+                                            title={
+                                                vault.name ||
+                                                truncateText(
+                                                    vault.description,
+                                                    50
+                                                )
+                                            }
                                             description={`Created on ${new Date(vault.createdAt).toLocaleDateString()}`}
                                             type="vault"
                                             id={vault.id}

--- a/app/web-app/src/app/(root)/spaces/[id]/page.tsx
+++ b/app/web-app/src/app/(root)/spaces/[id]/page.tsx
@@ -105,7 +105,9 @@ export default async function SpaceDetailsPage({
                         >
                             <CardContent className="p-6">
                                 <h3 className="text-lg font-semibold mb-2">
-                                    Vault {vault.id}
+                                    {vault.name
+                                        ? vault.name
+                                        : `Vault ${vault.id}`}
                                 </h3>
                                 <p className="text-sm text-gray-600 mb-6">
                                     {truncateText(vault.description, 100)}

--- a/app/web-app/src/app/api/vault/new/route.ts
+++ b/app/web-app/src/app/api/vault/new/route.ts
@@ -12,6 +12,7 @@ export async function POST(req: Request) {
 
         const {
             vaultAddress,
+            name,
             description,
             fundingTokenAddress,
             votingTokenAddress,
@@ -38,6 +39,7 @@ export async function POST(req: Request) {
         const votingTokenSymbol = await getTokenName(votingTokenAddress);
         const vault = await prisma.fundingVault.create({
             data: {
+                name,
                 description,
                 creatorAddress: session.user.address,
                 vaultAddress,

--- a/app/web-app/src/components/vault-details-card-wrapper.tsx
+++ b/app/web-app/src/components/vault-details-card-wrapper.tsx
@@ -21,6 +21,7 @@ import { type FundingVault } from '@prisma/client';
 import { getVaultBalance } from '@/lib/vault-data';
 import { truncateText } from '@/lib/truncate-text';
 import { Button } from '@/components/ui/button';
+import { WalletMinimal } from 'lucide-react';
 
 interface VaultDetailsCardWrapperProps {
     fundingVault: FundingVault;
@@ -49,6 +50,14 @@ export default async function VaultDetailsCardWrapper({
                     value={`#${vault.id}`}
                     description="Unique identifier for this funding vault"
                 />
+                {vault.name && (
+                    <StatCard
+                        title="Vault Name"
+                        icon={<WalletMinimal className="text-yellow-500" />}
+                        value={`${vault.name}`}
+                        description="Name for this funding vault"
+                    />
+                )}
                 <StatCard
                     title="Available Funds"
                     icon={<LockKeyhole className="text-green-500" />}

--- a/app/web-app/src/components/vault-form.tsx
+++ b/app/web-app/src/components/vault-form.tsx
@@ -49,6 +49,7 @@ import { useEffect } from 'react';
 import MoreInfo from '@/components/more-info';
 
 const createVaultFormSchema = z.object({
+    name: z.string(),
     description: z.string().min(1, 'Description is required.'),
     fundingTokenAddress: z
         .string()
@@ -100,6 +101,7 @@ export default function VaultForm({
     const form = useForm<z.infer<typeof createVaultFormSchema>>({
         resolver: zodResolver(createVaultFormSchema),
         defaultValues: {
+            name: '',
             description: '',
             fundingTokenAddress: '',
             votingTokenAddress: '',
@@ -153,6 +155,7 @@ export default function VaultForm({
                     hash: hash,
                 });
                 const response = await axios.post('/api/vault/new', {
+                    name: data.name,
                     description: data.description,
                     creatorAddress: address,
                     vaultAddress: result,
@@ -192,20 +195,29 @@ export default function VaultForm({
 
     function renderReviewStep() {
         const data = form.getValues();
+        const fieldOrder = [
+            'name',
+            'description',
+            'fundingTokenAddress',
+            'votingTokenAddress',
+            'minRequestableAmount',
+            'maxRequestableAmount',
+            'tallyDate',
+        ] as const;
         return (
             <Card className="w-full mx-auto flex flex-col h-[500px]">
                 <ScrollArea className="flex-grow">
                     <CardContent className="p-6 space-y-4">
-                        {Object.entries(data).map(([key, value]) => (
+                        {fieldOrder.map((field) => (
                             <div
-                                key={key}
+                                key={field}
                                 className="flex flex-col sm:flex-row sm:justify-between py-2 last:border-b-0"
                             >
                                 <span className="font-medium capitalize mb-1 sm:mb-0">
-                                    {key.replace(/([A-Z])/g, ' $1').trim()}:
+                                    {field.replace(/([A-Z])/g, ' $1').trim()}:
                                 </span>
                                 <span className="text-sm text-right sm:text-left sm:w-1/2 break-words">
-                                    {value.toString()}
+                                    {data[field].toString()}
                                 </span>
                             </div>
                         ))}
@@ -247,7 +259,29 @@ export default function VaultForm({
                     </p>
                 </div>
                 {currentVaultFormStep === 0 && (
-                    <div className="space-y-2 ">
+                    <div className="space-y-4 ">
+                        <FormField
+                            name="name"
+                            control={form.control}
+                            render={({ field }) => {
+                                return (
+                                    <FormItem>
+                                        <FormLabel>Vault Name</FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                disabled={formIsLoading}
+                                                placeholder="Name here..."
+                                                {...field}
+                                            />
+                                        </FormControl>
+                                        <FormDescription>
+                                            Name of the Vault
+                                        </FormDescription>
+                                        <FormMessage />
+                                    </FormItem>
+                                );
+                            }}
+                        />
                         <FormField
                             name="description"
                             control={form.control}


### PR DESCRIPTION
This PR addresses the issue outlined in the repository regarding the inability of users to specify custom titles for funding vaults during their creation. The changes allow users to input a custom vault name while maintaining backward compatibility by falling back to the default `vault#<vault id>` format when no name is provided. Resolves #56 

#### Changes Introduced
1. **Database Schema Updates**:
   - **File**: `prisma/migrations/20241210102725_add_name_field_in_funding_vault_model/migration.sql`
   - **Change**: Added a new column `name` (optional) to the `FundingVault` model.
   - **Justification**: The optional nature of this field ensures that existing records and functionalities are unaffected, thus supporting backward compatibility.

2. **Schema Update**:
   - **File**: `prisma/schema.prisma`
   - **Change**: Updated the `FundingVault` model to include the `name` field.

3. **Vault Display Changes**:
   - **File**: `src/app/(root)/profile/page.tsx`
   - **Change**: Updated the vault card's title to display the `name` field if present. Falls back to truncating the description if `name` is not available.
   - **File**: `src/app/(root)/spaces/[id]/page.tsx`
   - **Change**: Updated the space details page to display the vault's `name` if present; otherwise, it defaults to `Vault <vault id>`.

4. **API Updates for Vault Creation**:
   - **File**: `src/app/api/vault/new/route.ts`
   - **Change**: Added support for accepting the `name` field during the vault creation process. This value is stored in the database, falling back to the default behavior if no `name` is provided.

5. **Component Updates**:
   - **File**: `src/components/vault-details-card-wrapper.tsx`
   - **Change**: Added a new stat card to display the vault's `name` if present.

6. **Vault Form Updates**:
   - **File**: `src/components/vault-form.tsx`
   - **Change**: Added a new input field for `name` in the vault creation form. The field is optional, and the system uses the default naming convention if left empty.

#### Backward Compatibility
To ensure seamless integration and prevent breaking changes:
- The `name` field in the database is optional.
- The UI and API retain the current behavior of using the default `vault#<vault id>` format when `name` is not provided.
- Existing vault records and functionality are unaffected by these changes.

#### Testing
- **Unit Tests**: Verified the functionality of the `name` field in vault creation, display, and API integration.
- **Manual Testing**: Ensured that:
  - Vaults created without a name default to the `vault#<vault id>` format.
  - Vaults created with a custom name display the specified name in all relevant views.

#### Video Walkthrough:
https://drive.google.com/file/d/12syKBOxb4mFH1HkwqAwwP0KgCAvsnYCg/view?usp=sharing